### PR TITLE
Modernize workflow and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # agentSpace
-agentic framework for parsing agents
+
+Minimal framework for building tool-driven agents and workflows.
+
+## Running the example
+
+```bash
+python examples/document_analysis_workflow.py
+```
+
+This runs `examples/document_analysis_workflow.py`, a simple workflow that
+creates, reads and deletes a file using `FileTool`.

--- a/__main__.py
+++ b/__main__.py
@@ -1,8 +1,8 @@
-from examples.document_analysis_workflow import main
+from examples.document_analysis_workflow import main as example_main
 
 def main():
     """Main entry point for the agent"""
-    main()
+    example_main()
 
 if __name__ == "__main__":
     main()

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, Optional, List
 from datetime import datetime
 import logging
-from ..utils.logging import get_logger
+from utils.logging import get_logger
 
 class BaseAgent(ABC):
     """Base class for all agents"""

--- a/agent/llm_agent.py
+++ b/agent/llm_agent.py
@@ -1,8 +1,7 @@
-from ..agent.base_agent import BaseAgent
+from agent.base_agent import BaseAgent
 from openai import OpenAI
 from typing import Dict, Any, Optional
-import logging
-from ..utils.logging import get_logger
+from utils.logging import get_logger
 
 class LLMTool:
     """Tool for interacting with LLMs"""

--- a/examples/document_analysis_workflow.py
+++ b/examples/document_analysis_workflow.py
@@ -1,0 +1,41 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from workflow.tasks import Task
+from workflow.workflows import Workflow
+from toolLib.tool_registry import ToolRegistry
+from toolLib.file_tools import FileTool
+
+# Example tasks using FileTool
+class CreateFileTask(Task):
+    def execute(self, tool_registry: ToolRegistry):
+        file_tool = tool_registry.get_tool_instance(self.tool)
+        return file_tool.create_file(**self.parameters)
+
+class ReadFileTask(Task):
+    def execute(self, tool_registry: ToolRegistry):
+        file_tool = tool_registry.get_tool_instance(self.tool)
+        return file_tool.read_file(**self.parameters)
+
+class DeleteFileTask(Task):
+    def execute(self, tool_registry: ToolRegistry):
+        file_tool = tool_registry.get_tool_instance(self.tool)
+        return file_tool.delete_file(**self.parameters)
+
+
+def main():
+    registry = ToolRegistry()
+    registry.register_tool('file', FileTool)
+    registry.create_tool_instance('file', {'base_path': '.'})
+
+    wf = Workflow('demo', tool_registry=registry)
+    wf.add_task(CreateFileTask('create', 'file', {'path': 'demo.txt', 'content': 'hello world'}))
+    wf.add_task(ReadFileTask('read', 'file', {'path': 'demo.txt'}, dependencies=['create']))
+    wf.add_task(DeleteFileTask('delete', 'file', {'path': 'demo.txt'}, dependencies=['read']))
+
+    result = wf.execute()
+    print(result)
+
+if __name__ == '__main__':
+    main()

--- a/toolLib/email_tools.py
+++ b/toolLib/email_tools.py
@@ -4,8 +4,8 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email import encoders
 from typing import Dict, Any, List
-import logging
-from ..utils.logging import get_logger
+from utils.logging import get_logger
+from toolLib.tool_registry import ToolBase
 
 class EmailTool(ToolBase):
     """Tool for email operations"""

--- a/toolLib/file_tools.py
+++ b/toolLib/file_tools.py
@@ -2,8 +2,8 @@ import os
 import shutil
 from pathlib import Path
 from typing import Dict, Any, Optional
-import logging
-from ..utils.logging import get_logger
+from utils.logging import get_logger
+from toolLib.tool_registry import ToolBase
 
 class FileTool(ToolBase):
     """Tool for file operations"""
@@ -107,6 +107,19 @@ class FileTool(ToolBase):
         except Exception as e:
             self.logger.error(f"Failed to move file {src} to {dest}: {str(e)}")
             return {'success': False, 'error': str(e)}
+
+    def execute(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Dispatch file operations based on task parameters"""
+        operation = task.get('operation')
+        if operation == 'create':
+            return self.create_file(**task)
+        if operation == 'read':
+            return self.read_file(**task)
+        if operation == 'delete':
+            return self.delete_file(**task)
+        if operation == 'move':
+            return self.move_file(**task)
+        return {'success': False, 'error': 'Unknown operation'}
     
     def validate(self, task: Dict[str, Any]) -> bool:
         """

--- a/toolLib/tool_registry.py
+++ b/toolLib/tool_registry.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any, Type, Optional
-from abc import ABC
+from abc import ABC, abstractmethod
 import inspect
 
 class ToolRegistry:

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -1,34 +1,29 @@
 from typing import Dict, Any, Optional, List
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from datetime import datetime
-import logging
-from ..utils.logging import get_logger
-from ..toolLib.tool_registry import ToolRegistry
+from utils.logging import get_logger
+from toolLib.tool_registry import ToolRegistry
 
+@dataclass
 class Task(ABC):
     """Base class for workflow tasks"""
-    
-    def __init__(self, name: str, tool: str, parameters: Dict[str, Any], dependencies: Optional[List[str]] = None):
-        """
-        Initialize a task
-        
-        Args:
-            name (str): Task name
-            tool (str): Tool to use for task execution
-            parameters (Dict[str, Any]): Task parameters
-            dependencies (Optional[List[str]]): List of dependent task names
-        """
-        self.name = name
-        self.tool = tool
-        self.parameters = parameters
-        self.dependencies = dependencies or []
-        self.logger = get_logger(f'Task.{name}')
+
+    name: str
+    tool: str
+    parameters: Dict[str, Any]
+    dependencies: Optional[List[str]] = field(default_factory=list)
+    logger: Any = field(init=False)
+    state: Dict[str, Any] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.logger = get_logger(f'Task.{self.name}')
         self.state = {
             'status': 'pending',
             'start_time': None,
             'end_time': None,
             'result': None,
-            'error': None
+            'error': None,
         }
     
     @abstractmethod


### PR DESCRIPTION
## Summary
- add a simple document workflow example
- modernize `Task` and `Workflow` using dataclasses
- implement dispatch logic in `FileTool`
- clean up imports and fix example entry point
- update README instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python examples/document_analysis_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_684126dccbfc832b96216d5f01cb1140