### PR TITLE
Add Streamlit PowerPoint mapper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # agentSpace
-agentic framework for parsing agents
+
+Agentic framework for parsing agents.
+
+## Streamlit PowerPoint Mapper
+
+This repository includes a small Streamlit application (`streamlit_ppt_mapper.py`) that demonstrates how to populate a PowerPoint template with data from CSV files using an LLM.
+
+### Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   streamlit run streamlit_ppt_mapper.py
+   ```
+3. Provide your OpenAI API key, upload a PPTX template, a text file describing how the data should map into the slides, and one or more CSV files. The app will call the LLM to determine the mapping and return an updated presentation for download.
+
+The LLM response should be a JSON array of actions with fields `slide_index`, `placeholder`, and `text`. The app applies these actions using `python-pptx`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+pandas
+python-pptx
+openai

--- a/streamlit_ppt_mapper.py
+++ b/streamlit_ppt_mapper.py
@@ -1,0 +1,113 @@
+import streamlit as st
+import pandas as pd
+from io import BytesIO
+from pptx import Presentation
+import json
+import openai
+
+
+def call_llm(api_key: str, instructions: str, dataframes: list) -> str:
+    """Use OpenAI to interpret instructions and return actions in JSON."""
+    openai.api_key = api_key
+
+    csv_preview = "\n".join(
+        f"CSV {i+1}:\n{df.head().to_csv(index=False)}" for i, df in enumerate(dataframes)
+    )
+    prompt = (
+        "You are an assistant that maps CSV data to a PowerPoint template.\n"
+        f"Instructions:\n{instructions}\n"
+        "Here are previews of the CSV files:\n" + csv_preview + "\n"
+        "Respond with a JSON array of actions. Each action should have "
+        "'slide_index', 'placeholder', and 'text'."
+    )
+
+    response = openai.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def apply_actions(prs: Presentation, actions_json: str) -> Presentation:
+    """Apply LLM actions to the presentation."""
+    actions = json.loads(actions_json)
+    for action in actions:
+        slide_idx = action.get("slide_index")
+        placeholder = action.get("placeholder")
+        text = action.get("text")
+        if slide_idx is None or placeholder is None:
+            continue
+        try:
+            slide = prs.slides[slide_idx]
+        except IndexError:
+            continue
+        for shape in slide.shapes:
+            if not shape.has_text_frame:
+                continue
+            if shape.name == placeholder:
+                shape.text = text
+    return prs
+
+
+def main() -> None:
+    st.title("PowerPoint Data Mapper")
+    st.write(
+        "Upload a PPTX template, a text file with mapping instructions, and one or more CSV files."
+    )
+
+    pptx_file = st.file_uploader("PPTX Template", type=["pptx"])
+    instructions_file = st.file_uploader("Instructions (txt)", type=["txt"])
+    csv_files = st.file_uploader(
+        "CSV Files", type=["csv"], accept_multiple_files=True
+    )
+    api_key = st.text_input("OpenAI API Key", type="password")
+
+    if (
+        st.button("Generate Presentation")
+        and pptx_file
+        and instructions_file
+        and csv_files
+        and api_key
+    ):
+        try:
+            instructions = instructions_file.read().decode("utf-8")
+        except Exception as e:
+            st.error(f"Failed to read instructions: {e}")
+            return
+
+        dataframes = []
+        for f in csv_files:
+            try:
+                df = pd.read_csv(f)
+                dataframes.append(df)
+            except Exception as e:
+                st.error(f"Failed to read CSV {f.name}: {e}")
+                return
+
+        st.info("Contacting LLM...")
+        try:
+            actions_json = call_llm(api_key, instructions, dataframes)
+            st.text_area("LLM Response", actions_json, height=200)
+        except Exception as e:
+            st.error(f"LLM call failed: {e}")
+            return
+
+        prs = Presentation(BytesIO(pptx_file.read()))
+        try:
+            prs = apply_actions(prs, actions_json)
+            output = BytesIO()
+            prs.save(output)
+            st.success("Presentation generated!")
+            st.download_button(
+                label="Download Updated PPTX",
+                data=output.getvalue(),
+                file_name="updated.pptx",
+                mime="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            )
+        except Exception as e:
+            st.error(f"Failed to apply actions: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Streamlit application for mapping CSV data into PowerPoint templates using OpenAI
- document the new app in the README
- add requirements file for the Streamlit example

## Testing
- `python -m py_compile streamlit_ppt_mapper.py`
- `pytest`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6841299aed88832b8241971c59683881)