### PR TITLE
Add data cleansing agent workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ agentic framework for parsing agents
   agents.
 - **Hugging Face dataset agent**: `python examples/hf_dataset_agent.py` to fetch a
   public dataset (e.g., `ag_news` or `imdb`) using a STELLA-inspired loop that
-  scouts metadata, plans, executes, audits a download, and then runs an EDA
-  analyst to surface descriptive stats, correlations, and distribution insights.
-  Requires `pip install datasets`.
+  scouts metadata, plans, executes, audits a download, runs EDA, cleans the
+  dataframe, and then trains a simple baseline model with a train/test split.
+  Requires `pip install datasets scikit-learn`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ agentic framework for parsing agents
   agents.
 - **Hugging Face dataset agent**: `python examples/hf_dataset_agent.py` now
   defaults to the public `buio/heart-disease` dataset so you can see an
-  end-to-end retrieval → EDA → cleaning → AutoML model search pass with a
-  leaderboard and held-out accuracy printout. You can still provide a different
-  dataset, config, and split via CLI args (e.g., `python examples/hf_dataset_agent.py
-  ag_news None train`). Requires `pip install datasets scikit-learn`.
+  end-to-end retrieval → EDA → cleaning → AutoML model search pass with
+  lightweight hyperparameter sweeps, an auto-ensemble voting candidate, a
+  leaderboard, and a held-out accuracy printout. You can still provide a
+  different dataset, config, and split via CLI args (e.g., `python
+  examples/hf_dataset_agent.py ag_news None train`). Requires `pip install
+  datasets scikit-learn`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ agentic framework for parsing agents
   agents.
 - **Hugging Face dataset agent**: `python examples/hf_dataset_agent.py` now
   defaults to the public `buio/heart-disease` dataset so you can see an
-  end-to-end retrieval → EDA → cleaning → model-building pass with an accuracy
-  printout on the held-out set. You can still provide a different dataset,
-  config, and split via CLI args (e.g., `python examples/hf_dataset_agent.py
+  end-to-end retrieval → EDA → cleaning → AutoML model search pass with a
+  leaderboard and held-out accuracy printout. You can still provide a different
+  dataset, config, and split via CLI args (e.g., `python examples/hf_dataset_agent.py
   ag_news None train`). Requires `pip install datasets scikit-learn`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ agentic framework for parsing agents
 - **Data cleansing workflow**: `python examples/data_cleansing_workflow.py` to see a
   scan-plan-act-audit loop that cleans a toy dataframe using simple cooperative
   agents.
-- **Hugging Face dataset agent**: `python examples/hf_dataset_agent.py` to fetch a
-  public dataset (e.g., `ag_news` or `imdb`) using a STELLA-inspired loop that
-  scouts metadata, plans, executes, audits a download, runs EDA, cleans the
-  dataframe, and then trains a simple baseline model with a train/test split.
-  Requires `pip install datasets scikit-learn`.
+- **Hugging Face dataset agent**: `python examples/hf_dataset_agent.py` now
+  defaults to the public `buio/heart-disease` dataset so you can see an
+  end-to-end retrieval → EDA → cleaning → model-building pass with an accuracy
+  printout on the held-out set. You can still provide a different dataset,
+  config, and split via CLI args (e.g., `python examples/hf_dataset_agent.py
+  ag_news None train`). Requires `pip install datasets scikit-learn`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # agentSpace
 agentic framework for parsing agents
+
+## Examples
+
+- Install the minimal dependencies for the examples with
+`pip install pandas numpy pydantic`.
+
+- **Document analysis placeholder**: `python examples/document_analysis_workflow.py`
+- **Data cleansing workflow**: `python examples/data_cleansing_workflow.py` to see a
+  scan-plan-act-audit loop that cleans a toy dataframe using simple cooperative
+  agents.
+- **Module entrypoint**: `python __main__.py` runs the data cleansing workflow by
+  default.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ agentic framework for parsing agents
   agents.
 - **Hugging Face dataset agent**: `python examples/hf_dataset_agent.py` to fetch a
   public dataset (e.g., `ag_news` or `imdb`) using a STELLA-inspired loop that
-  scouts metadata, plans, executes, and audits a download. Requires `pip install
-  datasets`.
+  scouts metadata, plans, executes, audits a download, and then runs an EDA
+  analyst to surface descriptive stats, correlations, and distribution insights.
+  Requires `pip install datasets`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ agentic framework for parsing agents
   lightweight hyperparameter sweeps, an auto-ensemble voting candidate, a
   leaderboard, and a held-out accuracy printout. You can still provide a
   different dataset, config, and split via CLI args (e.g., `python
-  examples/hf_dataset_agent.py ag_news None train`). Requires `pip install
-  datasets scikit-learn`.
+  examples/hf_dataset_agent.py ag_news None train`). Pass `--save-dir
+  runs/latest` to persist `pivot.json`, `data_sample.csv`, and
+  `leaderboard.csv` for post-run review. Requires `pip install datasets
+  scikit-learn`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ agentic framework for parsing agents
   small encoder, walks through a reasoning chain that realigns to the pivot, and
   then runs both a control HellaSwag accuracy pass (causal LM log-likelihood) and
   a pivot-embedding cosine scorer for side-by-side accuracy deltas. Defaults to
-  30 validation samples; use `--eval-samples 0` for the full validation set or a
+  300 validation samples; use `--eval-samples 0` for the full validation set or a
   smaller integer for a quicker subset. Requires `pip install datasets
   transformers torch sentence-transformers`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by

--- a/README.md
+++ b/README.md
@@ -10,5 +10,9 @@ agentic framework for parsing agents
 - **Data cleansing workflow**: `python examples/data_cleansing_workflow.py` to see a
   scan-plan-act-audit loop that cleans a toy dataframe using simple cooperative
   agents.
-- **Module entrypoint**: `python __main__.py` runs the data cleansing workflow by
+- **Hugging Face dataset agent**: `python examples/hf_dataset_agent.py` to fetch a
+  public dataset (e.g., `ag_news` or `imdb`) using a STELLA-inspired loop that
+  scouts metadata, plans, executes, and audits a download. Requires `pip install
+  datasets`.
+- **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ agentic framework for parsing agents
   examples/pivot_embeddings_hellaswag.py` computes pivot embeddings with a
   small encoder, walks through a reasoning chain that realigns to the pivot, and
   then runs both a control HellaSwag accuracy pass (causal LM log-likelihood) and
-  a pivot-embedding cosine scorer for side-by-side accuracy deltas. Use
-  `--eval-samples 0` for the full validation set or a smaller integer for a quick
-  subset. Requires `pip install datasets transformers torch sentence-transformers`.
+  a pivot-embedding cosine scorer for side-by-side accuracy deltas. Defaults to
+  30 validation samples; use `--eval-samples 0` for the full validation set or a
+  smaller integer for a quicker subset. Requires `pip install datasets
+  transformers torch sentence-transformers`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -20,5 +20,11 @@ agentic framework for parsing agents
   runs/latest` to persist `pivot.json`, `data_sample.csv`, and
   `leaderboard.csv` for post-run review. Requires `pip install datasets
   scikit-learn`.
+- **Pivot embeddings + HellaSwag sanity check**: `python
+  examples/pivot_embeddings_hellaswag.py` computes pivot embeddings with a
+  small encoder, walks through a reasoning chain that realigns to the pivot, and
+  then runs a quick HellaSwag accuracy pass with a causal LM (default
+  `gpt2`) to ensure the model scores above zero. Requires `pip install datasets
+  transformers torch sentence-transformers`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ agentic framework for parsing agents
   runs/latest` to persist `pivot.json`, `data_sample.csv`, and
   `leaderboard.csv` for post-run review. Requires `pip install datasets
   scikit-learn`.
-- **Pivot embeddings + HellaSwag sanity check**: `python
+- **Pivot embeddings + HellaSwag comparison**: `python
   examples/pivot_embeddings_hellaswag.py` computes pivot embeddings with a
   small encoder, walks through a reasoning chain that realigns to the pivot, and
-  then runs a quick HellaSwag accuracy pass with a causal LM (default
-  `gpt2`) to ensure the model scores above zero. Requires `pip install datasets
-  transformers torch sentence-transformers`.
+  then runs both a control HellaSwag accuracy pass (causal LM log-likelihood) and
+  a pivot-embedding cosine scorer for side-by-side accuracy deltas. Use
+  `--eval-samples 0` for the full validation set or a smaller integer for a quick
+  subset. Requires `pip install datasets transformers torch sentence-transformers`.
 - **Module entrypoint**: `python __main__.py` runs the Hugging Face dataset agent by
   default.

--- a/__main__.py
+++ b/__main__.py
@@ -1,4 +1,4 @@
-from examples.document_analysis_workflow import main as example_main
+from examples.data_cleansing_workflow import main as example_main
 
 def main():
     """Main entry point for the agent"""

--- a/__main__.py
+++ b/__main__.py
@@ -1,4 +1,4 @@
-from examples.data_cleansing_workflow import main as example_main
+from examples.hf_dataset_agent import main as example_main
 
 def main():
     """Main entry point for the agent"""

--- a/examples/data_cleansing_workflow.py
+++ b/examples/data_cleansing_workflow.py
@@ -1,0 +1,339 @@
+"""Data cleansing workflow example using simple cooperative agents.
+
+This module demonstrates a small stateful pipeline that scans a pandas
+``DataFrame`` for known quality issues, plans a fix, executes the plan,
+and audits the results. It is intentionally written as a single,
+self-contained example so it can be run directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel
+
+
+# ==========================================
+# 1. THE STELLA PIVOT (Shared State)
+# ==========================================
+
+class ColumnEntity(BaseModel):
+    name: str
+    dtype: str
+    null_count: int
+    sample_values: List[Any]
+
+
+class DatasetEntity(BaseModel):
+    name: str
+    row_count: int
+    columns: Dict[str, ColumnEntity]
+
+
+class Issue(BaseModel):
+    id: str
+    column: Optional[str] = None
+    issue_type: str
+    severity: str
+    description: str
+
+
+class PlanStep(BaseModel):
+    step_id: int
+    target_issue_id: str
+    action_type: str
+    description: str
+    rationale: str
+
+
+class ActionLog(BaseModel):
+    step_id: int
+    code_executed: str
+    success: bool
+    error_message: Optional[str] = None
+    rows_affected: Optional[int] = 0
+
+
+class DataCleansingPivot(BaseModel):
+    """The single source of truth that all agents read/write."""
+
+    pivot_id: str
+    goal: str = "Prepare data for ML training"
+
+    # ENTITIES: The facts about the data
+    dataset_meta: DatasetEntity
+
+    # CONSTRAINTS: The rules of the road
+    constraints: List[str] = [
+        "Do not drop more than 5% of total rows",
+        "Preserve customer_id uniqueness",
+    ]
+
+    # STATE: What is currently wrong?
+    known_issues: List[Issue] = []
+    current_plan: Optional[PlanStep] = None
+
+    # MEMORY: What have we done?
+    action_log: List[ActionLog] = []
+    status: str = "scanning"
+
+
+# ==========================================
+# 2. THE MOCK LLM INTERFACE (Replace this!)
+# ==========================================
+
+
+def call_llm(system_prompt: str, user_prompt: str, mock_response: str | None = None):
+    """In production, replace this with an LLM call.
+
+    For this demo, it returns ``mock_response`` to simulate intelligence.
+    """
+
+    return mock_response
+
+
+# ==========================================
+# 3. THE NETS (The Agents)
+# ==========================================
+
+
+class ScannerNet:
+    """The Observer: updates dataset metadata and finds issues."""
+
+    def run(self, df: pd.DataFrame, pivot: DataCleansingPivot) -> DataCleansingPivot:
+        print("🔎 [Scanner] Profiling dataframe...")
+
+        # 1. Update Entities (Metadata)
+        pivot.dataset_meta.row_count = len(df)
+        pivot.dataset_meta.columns = {}
+
+        for col in df.columns:
+            pivot.dataset_meta.columns[col] = ColumnEntity(
+                name=col,
+                dtype=str(df[col].dtype),
+                null_count=int(df[col].isnull().sum()),
+                sample_values=df[col].dropna().head(3).tolist(),
+            )
+
+        # 2. Heuristic Check (Simulating LLM Insight)
+        pivot.known_issues = []
+
+        if "total_charges" in df.columns and df["total_charges"].dtype == "O":
+            pivot.known_issues.append(
+                Issue(
+                    id="iss_1",
+                    column="total_charges",
+                    issue_type="type_mismatch",
+                    severity="high",
+                    description="Column is Object but should be Numeric. Contains empty strings.",
+                )
+            )
+
+        if "tenure" in df.columns and df["tenure"].isnull().sum() > 0:
+            pivot.known_issues.append(
+                Issue(
+                    id="iss_2",
+                    column="tenure",
+                    issue_type="missing_values",
+                    severity="medium",
+                    description="Missing values found.",
+                )
+            )
+
+        pivot.status = "planning" if pivot.known_issues else "completed"
+        return pivot
+
+
+class StrategistNet:
+    """The Planner: decides what to do next based on the pivot."""
+
+    def run(self, pivot: DataCleansingPivot) -> DataCleansingPivot:
+        if not pivot.known_issues:
+            pivot.status = "completed"
+            return pivot
+
+        print("🧠 [Strategist] Planning fix for top issue...")
+
+        # Sort by severity (High > Medium > Low) — for the demo we take the first.
+        target_issue = pivot.known_issues[0]
+
+        system_prompt = (
+            "You are a Data Strategy Agent. Given a list of data issues and "
+            "constraints, propose a safe Python pandas operation to fix the highest "
+            "priority issue."
+        )
+        pivot_json = pivot.model_dump_json(exclude={"dataset_meta"})
+
+        _ = call_llm(system_prompt, pivot_json)  # Placeholder for future LLM wiring.
+
+        if target_issue.issue_type == "type_mismatch":
+            mock_plan_desc = "Convert to numeric using coerce errors, then fill NaNs with median."
+        elif target_issue.issue_type == "missing_values":
+            mock_plan_desc = "Impute missing values with the median of the column."
+        else:
+            mock_plan_desc = "Drop rows."
+
+        pivot.current_plan = PlanStep(
+            step_id=len(pivot.action_log) + 1,
+            target_issue_id=target_issue.id,
+            action_type="code_execution",
+            description=mock_plan_desc,
+            rationale="Constraints allow imputation; type conversion is required for ML.",
+        )
+
+        pivot.status = "executing"
+        return pivot
+
+
+class SurgeonNet:
+    """The Executor: generates and runs code."""
+
+    def run(self, df: pd.DataFrame, pivot: DataCleansingPivot) -> Tuple[pd.DataFrame, DataCleansingPivot]:
+        plan = pivot.current_plan
+        if plan is None:
+            raise ValueError("No plan to execute")
+
+        print(f"🔪 [Surgeon] Executing Plan: {plan.description}")
+
+        try:
+            rows_before = len(df)
+
+            if "Convert to numeric" in plan.description:
+                code = (
+                    "df['total_charges'] = pd.to_numeric(df['total_charges'], errors='coerce'); "
+                    "df['total_charges'] = df['total_charges'].fillna(df['total_charges'].median())"
+                )
+                df["total_charges"] = pd.to_numeric(df["total_charges"], errors="coerce")
+                df["total_charges"] = df["total_charges"].fillna(df["total_charges"].median())
+
+            elif "Impute missing" in plan.description:
+                code = "df['tenure'] = df['tenure'].fillna(df['tenure'].median())"
+                df["tenure"] = df["tenure"].fillna(df["tenure"].median())
+
+            else:
+                code = "# Unknown plan, pass"
+
+            rows_after = len(df)
+
+            pivot.action_log.append(
+                ActionLog(
+                    step_id=plan.step_id,
+                    code_executed=code,
+                    success=True,
+                    rows_affected=rows_before - rows_after,
+                )
+            )
+
+            pivot.known_issues = [i for i in pivot.known_issues if i.id != plan.target_issue_id]
+            pivot.current_plan = None
+            pivot.status = "auditing"
+
+        except Exception as exc:  # pragma: no cover - demo logging only
+            print(f"❌ [Surgeon] Error: {exc}")
+            pivot.action_log.append(
+                ActionLog(
+                    step_id=plan.step_id,
+                    code_executed="ERROR",
+                    success=False,
+                    error_message=str(exc),
+                )
+            )
+            pivot.status = "failed"
+
+        return df, pivot
+
+
+class AuditorNet:
+    """The Critic: checks safety and constraints."""
+
+    def run(self, df: pd.DataFrame, pivot: DataCleansingPivot) -> DataCleansingPivot:
+        print("⚖️ [Auditor] Verifying constraints...")
+
+        original_count = pivot.dataset_meta.row_count
+        current_count = len(df)
+        loss_pct = (original_count - current_count) / original_count
+
+        if loss_pct > 0.05:
+            print(f"⚠️ [Auditor] ALERT! Data loss {loss_pct*100}% exceeds 5% constraint.")
+            pivot.status = "failed"
+        else:
+            print("✅ [Auditor] Constraints passed.")
+            if pivot.known_issues:
+                pivot.status = "planning"
+            else:
+                pivot.status = "scanning"
+
+        return pivot
+
+
+# ==========================================
+# 4. ORCHESTRATION LOOP
+# ==========================================
+
+
+def run_stella_loop(df: pd.DataFrame) -> Tuple[pd.DataFrame, DataCleansingPivot]:
+    """Run the full scan-plan-act-audit loop on the provided dataframe."""
+
+    initial_meta = DatasetEntity(name="raw_data", row_count=len(df), columns={})
+    pivot = DataCleansingPivot(pivot_id="job_001", dataset_meta=initial_meta)
+
+    scanner = ScannerNet()
+    strategist = StrategistNet()
+    surgeon = SurgeonNet()
+    auditor = AuditorNet()
+
+    steps = 0
+    max_steps = 10
+
+    print(f"🚀 STELLA Initialized for {len(df)} rows.\n")
+
+    while pivot.status not in {"completed", "failed"} and steps < max_steps:
+        steps += 1
+        print(f"\n--- Cycle {steps} [State: {pivot.status}] ---")
+
+        if pivot.status == "scanning":
+            pivot = scanner.run(df, pivot)
+
+        elif pivot.status == "planning":
+            pivot = strategist.run(pivot)
+
+        elif pivot.status == "executing":
+            df, pivot = surgeon.run(df, pivot)
+
+        elif pivot.status == "auditing":
+            pivot = auditor.run(df, pivot)
+
+    if pivot.status == "completed":
+        print("\n✨ Data Cleansing Completed Successfully!")
+        print("Dataset Info:")
+        print(df.info())
+    else:
+        print("\n💀 Process Failed or Timed Out.")
+
+    return df, pivot
+
+
+# ==========================================
+# 5. DEMO EXECUTION
+# ==========================================
+
+
+def main() -> None:
+    data = {
+        "customer_id": [1, 2, 3, 4, 5],
+        "tenure": [12, 24, np.nan, 8, 15],
+        "total_charges": ["100.50", "200.00", " ", "450.20", "120.00"],
+    }
+    df_dirty = pd.DataFrame(data)
+
+    df_clean, final_pivot = run_stella_loop(df_dirty)
+
+    print("\n--- Final Pivot Action Log ---")
+    for log in final_pivot.action_log:
+        print(f"Step {log.step_id}: {log.code_executed} -> Success: {log.success}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hf_dataset_agent.py
+++ b/examples/hf_dataset_agent.py
@@ -1,0 +1,363 @@
+"""Hugging Face dataset retrieval agent using a STELLA-like loop.
+
+This example shows how a small set of cooperating agents can discover the
+metadata for a public Hugging Face dataset, plan how to retrieve the desired
+split, execute the download, and audit the result. The agents share a pivot
+object that acts as the single source of truth for decisions and logs.
+
+Usage:
+    python examples/hf_dataset_agent.py           # uses ag_news train split sample
+    python examples/hf_dataset_agent.py imdb test # different dataset and split
+
+Dependencies:
+    pip install datasets
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from datasets import Dataset, get_dataset_config_names, get_dataset_split_names, load_dataset
+from pydantic import BaseModel, Field
+
+
+# ==========================================
+# 1. THE STELLA PIVOT (Shared State)
+# ==========================================
+
+
+class Issue(BaseModel):
+    id: str
+    issue_type: str
+    severity: str
+    description: str
+
+
+class PlanStep(BaseModel):
+    step_id: int
+    target_issue_id: str
+    action_type: str
+    description: str
+    rationale: str
+
+
+class ActionLog(BaseModel):
+    step_id: int
+    code_executed: str
+    success: bool
+    error_message: Optional[str] = None
+    rows_affected: Optional[int] = 0
+
+
+@dataclass
+class DatasetRequest:
+    repo_id: str
+    config: Optional[str] = None
+    split: str = "train"
+    sample_size: int = 500
+
+
+class DatasetSnapshot(BaseModel):
+    repo_id: str
+    config: str
+    split: str
+    num_rows: int
+    columns: List[str]
+
+
+class DatasetPivot(BaseModel):
+    """Single source of truth for the dataset retrieval agents."""
+
+    pivot_id: str
+    request: DatasetRequest
+    available_configs: List[str] = Field(default_factory=list)
+    available_splits: Dict[str, List[str]] = Field(default_factory=dict)
+
+    dataset: Optional[DatasetSnapshot] = None
+    known_issues: List[Issue] = Field(default_factory=list)
+    current_plan: Optional[PlanStep] = None
+    action_log: List[ActionLog] = Field(default_factory=list)
+    status: str = "scanning"
+
+
+# ==========================================
+# 2. THE NETS (The Agents)
+# ==========================================
+
+
+class ScoutNet:
+    """Observer: fetch dataset metadata and surface issues."""
+
+    def run(self, pivot: DatasetPivot) -> DatasetPivot:
+        print("🔎 [Scout] Inspecting Hugging Face repository metadata...")
+        issues: List[Issue] = []
+
+        try:
+            config_names = get_dataset_config_names(pivot.request.repo_id)
+        except Exception as exc:  # noqa: BLE001 - display hub errors to the user
+            issues.append(
+                Issue(
+                    id="issue_repo_missing",
+                    issue_type="repo_not_found",
+                    severity="high",
+                    description=f"Unable to resolve dataset repo: {exc}",
+                )
+            )
+            pivot.known_issues = issues
+            pivot.available_configs = []
+            pivot.status = "planning"
+            return pivot
+
+        pivot.available_configs = config_names or [None]
+        requested_config = pivot.request.config or (config_names[0] if config_names else None)
+
+        if len(config_names) > 1 and pivot.request.config is None:
+            issues.append(
+                Issue(
+                    id="issue_choose_config",
+                    issue_type="config_selection",
+                    severity="medium",
+                    description="Multiple configs available; none selected.",
+                )
+            )
+
+        if requested_config is None:
+            issues.append(
+                Issue(
+                    id="issue_no_config",
+                    issue_type="config_unavailable",
+                    severity="high",
+                    description="No configuration could be determined for the dataset.",
+                )
+            )
+            pivot.known_issues = issues
+            pivot.status = "planning"
+            return pivot
+
+        pivot.available_splits[requested_config] = get_dataset_split_names(pivot.request.repo_id, requested_config)
+
+        if pivot.request.split not in pivot.available_splits[requested_config]:
+            issues.append(
+                Issue(
+                    id="issue_missing_split",
+                    issue_type="missing_split",
+                    severity="high",
+                    description=f"Requested split '{pivot.request.split}' is not available.",
+                )
+            )
+
+        if pivot.dataset is None:
+            issues.append(
+                Issue(
+                    id="issue_not_downloaded",
+                    issue_type="not_retrieved",
+                    severity="high",
+                    description="Dataset has not been downloaded yet.",
+                )
+            )
+
+        pivot.known_issues = issues
+        pivot.status = "planning" if issues else "completed"
+        return pivot
+
+
+class StrategistNet:
+    """Planner: determine the next best action to satisfy the request."""
+
+    def run(self, pivot: DatasetPivot) -> DatasetPivot:
+        if not pivot.known_issues:
+            pivot.status = "completed"
+            return pivot
+
+        issue = pivot.known_issues[0]
+        print(f"🧠 [Strategist] Planning fix for issue: {issue.issue_type}")
+
+        if issue.issue_type == "config_selection":
+            description = "Select the first available configuration as default."
+            action = "set_config"
+        elif issue.issue_type == "missing_split":
+            description = "Switch to the first available split for the chosen config."
+            action = "set_split"
+        elif issue.issue_type == "not_retrieved":
+            description = "Download the requested dataset split and trim to sample size."
+            action = "download_dataset"
+        elif issue.issue_type == "repo_not_found":
+            description = "Stop because the dataset repository is unavailable."
+            action = "abort"
+        else:
+            description = "Abort due to unresolved configuration issues."
+            action = "abort"
+
+        pivot.current_plan = PlanStep(
+            step_id=len(pivot.action_log) + 1,
+            target_issue_id=issue.id,
+            action_type=action,
+            description=description,
+            rationale="Follow STELLA loop to satisfy dataset request safely.",
+        )
+        pivot.status = "executing"
+        return pivot
+
+
+class OperatorNet:
+    """Executor: perform the planned action."""
+
+    def run(self, pivot: DatasetPivot) -> Tuple[Optional[Dataset], DatasetPivot]:
+        plan = pivot.current_plan
+        if plan is None:
+            raise ValueError("No plan to execute")
+
+        dataset: Optional[Dataset] = None
+        print(f"🔧 [Operator] Action: {plan.description}")
+
+        try:
+            if plan.action_type == "set_config":
+                pivot.request.config = pivot.available_configs[0]
+                code = "request.config = available_configs[0]"
+                pivot.status = "scanning"
+            elif plan.action_type == "set_split":
+                pivot.request.split = pivot.available_splits[pivot.request.config or pivot.available_configs[0]][0]
+                code = "request.split = first_available_split"
+                pivot.status = "scanning"
+            elif plan.action_type == "download_dataset":
+                dataset = load_dataset(
+                    pivot.request.repo_id,
+                    pivot.request.config,
+                    split=pivot.request.split,
+                )
+                if pivot.request.sample_size and len(dataset) > pivot.request.sample_size:
+                    dataset = dataset.select(range(pivot.request.sample_size))
+
+                pivot.dataset = DatasetSnapshot(
+                    repo_id=pivot.request.repo_id,
+                    config=pivot.request.config or pivot.available_configs[0],
+                    split=pivot.request.split,
+                    num_rows=len(dataset),
+                    columns=list(dataset.features.keys()),
+                )
+                code = "dataset = load_dataset(...); optional select(sample_size)"
+                pivot.status = "auditing"
+            else:
+                code = "abort"
+                pivot.status = "failed"
+                raise RuntimeError("Aborting per plan")
+
+            pivot.known_issues = [i for i in pivot.known_issues if i.id != plan.target_issue_id]
+            pivot.current_plan = None
+
+            pivot.action_log.append(
+                ActionLog(
+                    step_id=plan.step_id,
+                    code_executed=code,
+                    success=True,
+                    rows_affected=pivot.dataset.num_rows if pivot.dataset else 0,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - operator should expose actual error
+            pivot.action_log.append(
+                ActionLog(
+                    step_id=plan.step_id,
+                    code_executed=plan.action_type,
+                    success=False,
+                    error_message=str(exc),
+                )
+            )
+            pivot.status = "failed"
+            print(f"❌ [Operator] Error executing plan: {exc}")
+
+        return dataset, pivot
+
+
+class AuditorNet:
+    """Critic: check post-conditions and mark completion."""
+
+    def run(self, pivot: DatasetPivot) -> DatasetPivot:
+        print("⚖️ [Auditor] Verifying retrieved dataset...")
+
+        if pivot.dataset is None:
+            pivot.status = "failed"
+            print("❌ [Auditor] No dataset snapshot found; retrieval failed.")
+            return pivot
+
+        if pivot.dataset.num_rows == 0:
+            pivot.status = "failed"
+            print("❌ [Auditor] Dataset is empty after retrieval.")
+            return pivot
+
+        print(
+            f"✅ [Auditor] Retrieved {pivot.dataset.num_rows} rows "
+            f"with columns: {', '.join(pivot.dataset.columns)}"
+        )
+        pivot.status = "completed"
+        return pivot
+
+
+# ==========================================
+# 3. ORCHESTRATION LOOP
+# ==========================================
+
+
+def run_stella_loop(request: DatasetRequest) -> Tuple[Optional[Dataset], DatasetPivot]:
+    pivot = DatasetPivot(
+        pivot_id="hf_job_001",
+        request=request,
+    )
+
+    scout = ScoutNet()
+    strategist = StrategistNet()
+    operator = OperatorNet()
+    auditor = AuditorNet()
+
+    dataset: Optional[Dataset] = None
+    steps = 0
+    max_steps = 12
+
+    print(f"🚀 HF Agent initialized for repo '{request.repo_id}'.\n")
+
+    while pivot.status not in {"completed", "failed"} and steps < max_steps:
+        steps += 1
+        print(f"\n--- Cycle {steps} [State: {pivot.status}] ---")
+
+        if pivot.status == "scanning":
+            pivot = scout.run(pivot)
+        elif pivot.status == "planning":
+            pivot = strategist.run(pivot)
+        elif pivot.status == "executing":
+            dataset, pivot = operator.run(pivot)
+        elif pivot.status == "auditing":
+            pivot = auditor.run(pivot)
+
+    if pivot.status == "completed":
+        print("\n✨ Dataset retrieved successfully!")
+    else:
+        print("\n💀 Retrieval process failed or timed out.")
+
+    return dataset, pivot
+
+
+# ==========================================
+# 4. DEMO ENTRYPOINT
+# ==========================================
+
+
+def main(repo_id: str = "ag_news", config: Optional[str] = None, split: str = "train", sample_size: int = 200):
+    request = DatasetRequest(repo_id=repo_id, config=config, split=split, sample_size=sample_size)
+    dataset, pivot = run_stella_loop(request)
+
+    if dataset is not None:
+        print("\n--- Sample rows ---")
+        print(dataset.to_pandas().head())
+
+    print("\n--- Action Log ---")
+    for log in pivot.action_log:
+        print(f"Step {log.step_id}: {log.code_executed} -> Success: {log.success}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    repo = sys.argv[1] if len(sys.argv) > 1 else "ag_news"
+    cfg = sys.argv[2] if len(sys.argv) > 2 else None
+    split = sys.argv[3] if len(sys.argv) > 3 else "train"
+    main(repo, cfg, split)

--- a/examples/pivot_embeddings_hellaswag.py
+++ b/examples/pivot_embeddings_hellaswag.py
@@ -242,7 +242,7 @@ def main() -> None:
     parser.add_argument(
         "--eval-samples",
         type=int,
-        default=32,
+        default=30,
         help="Number of HellaSwag validation samples (0 or None for full set)",
     )
     parser.add_argument("--device", default="cpu", help="Torch device")

--- a/examples/pivot_embeddings_hellaswag.py
+++ b/examples/pivot_embeddings_hellaswag.py
@@ -1,0 +1,222 @@
+"""Pivot embedding demo plus a HellaSwag sanity check with a real model.
+
+This script stitches together two ideas:
+1) Pivot embeddings to keep multi-step reasoning centered on a goal.
+2) A quick HellaSwag benchmark using a small causal LM so we can confirm a
+   non-zero accuracy with an actual model (default: gpt2).
+
+Usage examples:
+    python examples/pivot_embeddings_hellaswag.py
+    python examples/pivot_embeddings_hellaswag.py --model gpt2 --eval-samples 64
+
+Dependencies:
+    pip install datasets transformers torch
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from transformers import AutoModel, AutoModelForCausalLM, AutoTokenizer
+
+
+# -----------------------------
+# Core helpers
+# -----------------------------
+
+def l2_normalize(vector: np.ndarray, eps: float = 1e-9) -> np.ndarray:
+    norm = np.linalg.norm(vector) + eps
+    return vector / norm
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray, eps: float = 1e-9) -> float:
+    a_n = l2_normalize(a, eps)
+    b_n = l2_normalize(b, eps)
+    return float(np.dot(a_n, b_n))
+
+
+# -----------------------------
+# Embedding backend
+# -----------------------------
+
+@dataclass
+class EmbeddingBackend:
+    model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
+
+    def __post_init__(self) -> None:
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self.model = AutoModel.from_pretrained(self.model_name)
+        self.model.eval()
+
+    @torch.inference_mode()
+    def encode(self, texts: Iterable[str]) -> np.ndarray:
+        if isinstance(texts, str):
+            texts = [texts]
+        encoding = self.tokenizer(list(texts), padding=True, truncation=True, return_tensors="pt")
+        outputs = self.model(**encoding)
+        token_embeddings = outputs.last_hidden_state
+        attention_mask = encoding.attention_mask.unsqueeze(-1)
+        summed = (token_embeddings * attention_mask).sum(dim=1)
+        counts = attention_mask.sum(dim=1).clamp(min=1)
+        mean_pooled = summed / counts
+        return l2_normalize(mean_pooled.detach().cpu().numpy())
+
+
+TASK_TYPES = ["math", "planning", "coding", "analysis", "generic"]
+TASK_VECTORS = {task: None for task in TASK_TYPES}
+W1, W2, W3 = 0.6, 0.2, 0.2
+
+
+def _task_vector(task: str, encoder: EmbeddingBackend) -> np.ndarray:
+    task = task if task in TASK_VECTORS else "generic"
+    cached = TASK_VECTORS[task]
+    if cached is None:
+        TASK_VECTORS[task] = encoder.encode([f"task type: {task}"])[0]
+    return TASK_VECTORS[task]
+
+
+def compute_pivot_embedding(
+    prompt: str,
+    history_summary: str = "",
+    task_type: str = "generic",
+    encoder: EmbeddingBackend | None = None,
+) -> np.ndarray:
+    encoder = encoder or EmbeddingBackend()
+    e_prompt = encoder.encode([prompt])[0]
+    e_history = encoder.encode([history_summary])[0] if history_summary else np.zeros_like(e_prompt)
+    e_task = _task_vector(task_type, encoder)
+    pivot_raw = W1 * e_prompt + W2 * e_history + W3 * e_task
+    return l2_normalize(pivot_raw)
+
+
+def encode_step(step_text: str, encoder: EmbeddingBackend) -> np.ndarray:
+    return encoder.encode([step_text])[0]
+
+
+def realign_step_to_pivot(step_text: str) -> str:
+    return f"[REALIGNED TO PIVOT] {step_text}"
+
+
+def process_step_with_pivot(
+    step_text: str,
+    pivot: np.ndarray,
+    encoder: EmbeddingBackend,
+    alignment_threshold: float = 0.65,
+    alpha: float = 0.9,
+) -> Tuple[str, np.ndarray, float]:
+    step_emb = encode_step(step_text, encoder)
+    sim = cosine_similarity(step_emb, pivot)
+
+    if sim < alignment_threshold:
+        step_text = realign_step_to_pivot(step_text)
+        step_emb = encode_step(step_text, encoder)
+        sim = cosine_similarity(step_emb, pivot)
+
+    pivot_raw = alpha * pivot + (1.0 - alpha) * step_emb
+    return step_text, l2_normalize(pivot_raw), sim
+
+
+# -----------------------------
+# HellaSwag evaluator
+# -----------------------------
+
+def score_ending(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    context: str,
+    ending: str,
+    device: torch.device,
+) -> float:
+    context_ids = tokenizer(context, return_tensors="pt").to(device)
+    full_ids = tokenizer(context + " " + ending, return_tensors="pt").to(device)
+    with torch.inference_mode():
+        outputs = model(**full_ids)
+        logprobs = torch.log_softmax(outputs.logits, dim=-1)
+
+    prefix_len = context_ids.input_ids.shape[1]
+    target_ids = full_ids.input_ids[0, prefix_len:]
+    token_logprobs = logprobs[0, prefix_len - 1 : -1, :]
+    selected = token_logprobs.gather(1, target_ids.unsqueeze(-1)).squeeze(-1)
+    return float(selected.sum().cpu())
+
+
+def evaluate_hellaswag(
+    model_name: str = "gpt2",
+    max_samples: int = 32,
+    device: str = "cpu",
+) -> float:
+    print(f"🚀 [HellaSwag] Loading model {model_name} on {device}...")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
+    model.eval()
+
+    print(f"📦 [HellaSwag] Fetching first {max_samples} validation samples...")
+    dataset = load_dataset("hellaswag", split=f"validation[:{max_samples}]")
+
+    correct = 0
+    for example in dataset:
+        context = (example["ctx_a"] + " " + example["ctx_b"]).strip()
+        endings: Sequence[str] = example["endings"]
+        scores = [score_ending(model, tokenizer, context, ending, model.device) for ending in endings]
+        prediction = int(np.argmax(scores))
+        if prediction == int(example["label"]):
+            correct += 1
+
+    accuracy = correct / len(dataset)
+    print(f"✅ [HellaSwag] Accuracy: {accuracy:.3f} over {len(dataset)} samples")
+    return accuracy
+
+
+# -----------------------------
+# Demo runner
+# -----------------------------
+
+def demo_pivot_chain(encoder: EmbeddingBackend) -> None:
+    prompt = "Plan a 6-month roadmap to ship a production-grade AutoML platform."
+    history = "Discussed STELLA agents, HF datasets, and AutoML leaderboards."
+    pivot = compute_pivot_embedding(prompt=prompt, history_summary=history, task_type="planning", encoder=encoder)
+
+    steps: List[str] = [
+        "Clarify user outcomes and success metrics for the platform.",
+        "Enumerate data connectors, feature store, and orchestration needs.",
+        "Start talking about unrelated movie plots.",
+        "Draft a phased deployment plan with safety gates.",
+    ]
+
+    print("\n=== REASONING CHAIN WITH PIVOT EMBEDDING ===\n")
+    for idx, step in enumerate(steps, start=1):
+        aligned_step, pivot, similarity = process_step_with_pivot(
+            step_text=step,
+            pivot=pivot,
+            encoder=encoder,
+            alignment_threshold=0.65,
+            alpha=0.9,
+        )
+        print(f"After Step {idx}:")
+        print(f"  Text      : {aligned_step}")
+        print(f"  Alignment : {similarity:.3f}")
+        print("-" * 60)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pivot embedding demo + HellaSwag check")
+    parser.add_argument("--model", default="gpt2", help="Causal LM to score HellaSwag endings")
+    parser.add_argument("--embedder", default="sentence-transformers/all-MiniLM-L6-v2", help="Embedding model for pivot alignment")
+    parser.add_argument("--eval-samples", type=int, default=32, help="Number of HellaSwag validation samples")
+    parser.add_argument("--device", default="cpu", help="Torch device")
+    args = parser.parse_args()
+
+    encoder = EmbeddingBackend(model_name=args.embedder)
+    demo_pivot_chain(encoder)
+    evaluate_hellaswag(model_name=args.model, max_samples=args.eval_samples, device=args.device)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pivot_embeddings_hellaswag.py
+++ b/examples/pivot_embeddings_hellaswag.py
@@ -242,7 +242,7 @@ def main() -> None:
     parser.add_argument(
         "--eval-samples",
         type=int,
-        default=30,
+        default=300,
         help="Number of HellaSwag validation samples (0 or None for full set)",
     )
     parser.add_argument("--device", default="cpu", help="Torch device")


### PR DESCRIPTION
## Summary
- add a self-contained data cleansing workflow that demonstrates scanner, planner, executor, and auditor agents
- point the module entrypoint at the new workflow and document how to run it
- add quick dependency notes for running the examples

## Testing
- python examples/data_cleansing_workflow.py
- python __main__.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69267aac19c0832b8ec3f6c685ee24b0)